### PR TITLE
feat(useForm): support return type for validating functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 es
 lib
+.idea

--- a/src/useForm/index.ts
+++ b/src/useForm/index.ts
@@ -181,13 +181,13 @@ function useForm(
   initialModel: Props;
   validateInfos: validateInfos;
   resetFields: () => void;
-  validate: (names?: string | string[], option?: validateOptions) => Promise<any>;
-  validateField: (
+  validate: <T = any>(names?: string | string[], option?: validateOptions) => Promise<T>;
+  validateField: <T = any>(
     name?: string,
     value?: any,
     rules?: [Record<string, unknown>],
     option?: validateOptions,
-  ) => Promise<any>;
+  ) => Promise<T>;
   mergeValidateInfo: (items: validateInfo | validateInfo[]) => validateInfo;
 } {
   const initialModel = cloneDeep(modelRef);
@@ -275,7 +275,7 @@ function useForm(
 
     return returnPromise;
   };
-  const validateField = (name: string, value: any, rules: any, option: validateOptions) => {
+  const validateField = <T extends unknown = any>(name: string, value: any, rules: any, option: validateOptions): Promise<T> => {
     const promise = validateRules(
       [name],
       value,
@@ -298,7 +298,7 @@ function useForm(
     return promise;
   };
 
-  const validate = (names?: namesType, option?: validateOptions) => {
+  const validate = <T extends unknown = any>(names?: namesType, option?: validateOptions): Promise<T> => {
     let keys = [];
     let strict = true;
     if (!names) {


### PR DESCRIPTION
According https://github.com/vueComponent/use/issues/19 this will introduce the possibility to use a return type for the validate functions of the `useForm`

Example

```
interface User {
  firstName: string
  lastName: string
  email: string
}

const modelRef = reactive({
  firstName: '',
  lastName: '',
  email: '',
})

const rulesRef = reactive({
  firstName: [
    {
      required: true,
      message: 'Please enter your first name',
    },
  ],
  lastName: [
    {
      required: true,
      message: 'Please enter your last name',
    },
  ],
  email: [
    {
      required: true,
      message: 'Please enter your Email Address',
    },
    {
      pattern: /^\S+@\S+$/,
      message: 'Please enter a valid Email Address',
    },
  ],
})

const { validate, validateInfos } = useForm(modelRef, rulesRef)
const user = await <User>validate()        
```