### PR TITLE
feat(use-form): add updated values to update the model

### DIFF
--- a/src/useForm/__demo__/index.tsx
+++ b/src/useForm/__demo__/index.tsx
@@ -59,6 +59,12 @@ export default {
       e.preventDefault();
       resetFields();
     };
+    const handleResetWithValues = e => {
+      e.preventDefault();
+      resetFields({
+        name2: 'updated values',
+      });
+    };
     return () => (
       <Form>
         <Form.Item
@@ -93,6 +99,7 @@ export default {
         </Form.Item>
         <button onClick={handleClick}>submit</button>
         <button onClick={handleReset}>reset</button>
+        <button onClick={handleResetWithValues}>reset with new updated Values</button>
       </Form>
     );
   },

--- a/src/useForm/index.ts
+++ b/src/useForm/index.ts
@@ -180,7 +180,7 @@ function useForm(
   rulesRef: Props;
   initialModel: Props;
   validateInfos: validateInfos;
-  resetFields: () => void;
+  resetFields: (newValues?: Props) => void;
   validate: (names?: string | string[], option?: validateOptions) => Promise<any>;
   validateField: (
     name?: string,
@@ -200,8 +200,11 @@ function useForm(
     };
   });
   validateInfos = reactive(validateInfos);
-  const resetFields = () => {
-    Object.assign(modelRef, cloneDeep(initialModel));
+  const resetFields = (newValues: Props) => {
+    Object.assign(modelRef, {
+      ...cloneDeep(initialModel),
+      ...newValues,
+    });
     //modelRef = resetReactiveValue(initialModel, modelRef);
     nextTick(() => {
       Object.keys(validateInfos).forEach(key => {


### PR DESCRIPTION
This PR add the option to update the RefModel with the `resetFields()` function. 

There are situations that after an `ajax` call, you need to update the model and call `resetFields` to update the validations.